### PR TITLE
ブロック機能のリアルタイム対応を実装（検索結果・リクエスト一覧の即時反映）

### DIFF
--- a/app/channels/chat_channel.rb
+++ b/app/channels/chat_channel.rb
@@ -1,0 +1,9 @@
+class ChatChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "chat_#{params[:chat_id]}"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -1,19 +1,53 @@
 class BlocksController < ApplicationController
   before_action :authenticate_user!
+
   def create
     blocked_user = User.find(params[:blocked_user_id])
+    return if current_user.id == blocked_user.id
 
-    # リクエスト削除
+    # 双方向リクエスト削除
     FriendRequest.where(sender: blocked_user, receiver: current_user).destroy_all
     FriendRequest.where(sender: current_user, receiver: blocked_user).destroy_all
 
-    current_user.blocks.create(blocked_user:)
-    redirect_back fallback_location: root_path
+    Block.find_or_create_by(user: current_user, blocked_user: blocked_user)
+
+    broadcast_friend_requests(current_user)
+    broadcast_search_results(current_user)
+    broadcast_search_results(blocked_user)
+
+    head :ok
   end
 
-  def destroy
-    block = current_user.blocks.find_by(blocked_user_id: params[:id])
-    block.destroy if block
-    redirect_back fallback_location: root_path
+  private
+
+  def broadcast_friend_requests(user)
+    html = render_to_string(
+      partial: 'layouts/leftSide/personal_chat/friend_requests',
+      locals: {
+        friend_requests: user.received_friend_requests.pending
+                            .where.not(sender_id: user.blocked_users.ids + user.blockers.ids)
+      }
+    )
+    ActionCable.server.broadcast("friend_requests_#{user.id}", html)
+  end
+
+  def broadcast_search_results(user)
+    keyword = session[:last_search_keyword] || ''
+    blocked_ids = user.blocked_users.ids + user.blockers.ids
+
+    users = User.where('name LIKE ?', "%#{keyword}%")
+                .where.not(id: blocked_ids)
+                .where.not(id: user.id)
+
+    html = render_to_string(
+      partial: 'layouts/leftSide/personal_chat/search_results',
+      locals: {
+        users: users,
+        search_results: users,
+        current_user: user
+      }
+    )
+
+    ActionCable.server.broadcast("friend_search_#{user.id}", html)
   end
 end

--- a/app/controllers/friend_requests_controller.rb
+++ b/app/controllers/friend_requests_controller.rb
@@ -1,47 +1,107 @@
 class FriendRequestsController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @friend_requests = current_user.received_friend_requests
+                                   .pending
+                                   .where.not(sender_id: current_user.blocked_users.ids + current_user.blockers.ids)
+    render partial: 'layouts/leftSide/personal_chat/friend_requests', locals: { friend_requests: @friend_requests }
+  end
+
   def create
     receiver = User.find(params[:receiver_id])
 
-    # すでに友達 or リクエスト済みなら無視
+    # すでに友達 or リクエスト中なら無視
     if current_user.friends.include?(receiver) ||
        current_user.sent_friend_requests.where(receiver_id: receiver.id, status: 'pending').exists?
       head :conflict and return
     end
 
-    friend_request = current_user.sent_friend_requests.build(receiver:)
+    friend_request = current_user.sent_friend_requests.find_by(receiver_id: receiver.id)
 
-    if friend_request.save
-
-      html_for_sender = render_to_string(
-        partial: 'layouts/leftSide/personal_chat/request_button',
-        locals: { user: receiver, current_user: current_user }
-      )
-
-      html_for_receiver = render_to_string(
-        partial: 'layouts/leftSide/personal_chat/request_button',
-        locals: { user: current_user, current_user: receiver }
-      )
-
-      FriendsChannel.broadcast_to("friend_request_btn_#{receiver.id}", html_for_sender)
-      FriendsChannel.broadcast_to("friend_request_btn_#{current_user.id}", html_for_receiver)
-      head :ok
+    if friend_request.present?
+      if friend_request.status == 'pending'
+        head :conflict and return
+      else
+        friend_request.update(status: 'pending')
+      end
     else
-      render json: { error: '友達申請に失敗しました' }, status: :unprocessable_entity
+      friend_request = current_user.sent_friend_requests.build(receiver: receiver)
+      friend_request.save
     end
+
+    # 送信者側
+    html_for_sender = render_to_string(
+      partial: 'layouts/leftSide/personal_chat/request_button',
+      locals: {
+        user: receiver,
+        current_user: current_user,
+        friend_request: friend_request
+      }
+    )
+
+    # 相手側
+    html_for_receiver = render_to_string(
+      partial: 'layouts/leftSide/personal_chat/request_button',
+      locals: {
+        user: current_user,
+        current_user: receiver,
+        friend_request: friend_request
+      }
+    )
+
+    # receiverに送る
+    ActionCable.server.broadcast(
+      "friend_requests_btn_#{receiver.id}",
+      {
+        action: 'reload_requests',
+        userId: current_user.id,
+        html: html_for_receiver
+      }
+    )
+
+    render html: html_for_sender.html_safe
   end
 
   def update
+    logger.debug "🧪 params[:id]: #{params[:id]}"
+    logger.debug "🧪 params[:status]: #{params[:status]}"
     @friend_request = FriendRequest.find(params[:id])
     process_request(@friend_request)
 
     if params[:status] == 'accepted'
       broadcast_friend_list(@friend_request.sender)
       broadcast_friend_list(@friend_request.receiver)
+
+      html = render_to_string(
+        partial: 'layouts/leftSide/personal_chat/request_button',
+        locals: {
+          user: @friend_request.sender,
+          current_user: @friend_request.receiver,
+          friend_request: @friend_request
+        }
+      )
+
+      render html: html.html_safe
+
+    elsif params[:status] == 'rejected'
+      logger.debug '🧪 Rejected分岐入りました'
+      ActionCable.server.broadcast(
+        "friend_requests_btn_#{@friend_request.sender.id}",
+        { action: 'reload_requests' }
+      )
+
+      broadcast_search_results(@friend_request.receiver)
+      broadcast_search_results(@friend_request.sender)
+
+      head :ok
+
+    else
+      logger.debug '🧪 Else分岐入りました'
+      # 拒否時 → リクエスト一覧のみ更新、ボタンは変更しない
+      broadcast_friend_requests(@friend_request.receiver)
+      head :ok
     end
-    broadcast_friend_requests(@friend_request.receiver)
-    head :ok
   end
 
   private
@@ -78,5 +138,25 @@ class FriendRequestsController < ApplicationController
       }
     )
     ActionCable.server.broadcast("friend_requests_#{user.id}", html)
+  end
+
+  def broadcast_search_results(user)
+    keyword = session[:last_search_keyword] || ''
+    blocked_ids = user.blocked_users.ids + user.blockers.ids
+
+    users = User.where('name LIKE ?', "%#{keyword}%")
+                .where.not(id: blocked_ids)
+                .where.not(id: user.id)
+
+    html = render_to_string(
+      partial: 'layouts/leftSide/personal_chat/search_results',
+      locals: {
+        users: users,
+        search_results: users,
+        current_user: user
+      }
+    )
+
+    ActionCable.server.broadcast("friend_search_#{user.id}", html)
   end
 end

--- a/app/javascript/channels/chat_channel.js
+++ b/app/javascript/channels/chat_channel.js
@@ -1,7 +1,7 @@
 import consumer from "channels/consumer";
 
 export const subscribeToChat = (chatId, callback) => {
-  return consumer.subscriptions.create(
+  const subscription = consumer.subscriptions.create(
     { channel: "ChatChannel", chat_id: chatId },
     {
       connected() {
@@ -19,4 +19,5 @@ export const subscribeToChat = (chatId, callback) => {
       },
     }
   );
+  return subscription;
 };

--- a/app/javascript/channels/friend_requests_channel.js
+++ b/app/javascript/channels/friend_requests_channel.js
@@ -7,18 +7,21 @@ if (userId) {
     { channel: "FriendRequestsChannel", id: userId },
     {
       connected() {
-        console.log(`Subscribed to FriendRequestsChannel for user ${userId}`);
+        if (process.env.NODE_ENV === "development") {
+          console.log(
+            `Subscribed to FriendRequestsChannel for user ${userId}`
+          );
+        }
       },
-
       disconnected() {
-        console.log(
-          `Unsubscribed from FriendRequestsChannel for user ${userId}`
-        );
+        if (process.env.NODE_ENV === "development") {
+          console.log(
+            `Unsubscribed from FriendRequestsChannel for user ${userId}`
+          );
+        }
       },
 
       received(data) {
-        console.log("📦 received:", data);
-
         if (data.action === "reload_requests") {
           fetch("/friend_requests", {
             headers: { Accept: "text/html" },
@@ -28,9 +31,8 @@ if (userId) {
               const container = document.querySelector("#friend-requests");
               if (container) {
                 container.innerHTML = html;
-                console.log("友達リクエスト一覧再描画");
-              } else {
-                console.warn("⚠ #friend-requests が見つかりません");
+              } else if (process.env.NODE_ENV === "development") {
+                console.warn("#friend-requests が見つかりません");
               }
             });
 
@@ -42,9 +44,8 @@ if (userId) {
 
             if (target) {
               target.outerHTML = data.html;
-              console.log("request_button を承認中に更新");
-            } else {
-              console.warn("⚠ request_button の DOM が見つかりません");
+            } else if (process.env.NODE_ENV === "development") {
+              console.warn("request_button の DOM が見つかりません");
             }
           }
         }

--- a/app/javascript/controllers/friend_request_buttons_controller.js
+++ b/app/javascript/controllers/friend_request_buttons_controller.js
@@ -14,16 +14,8 @@ export default class extends Controller {
   reject() {
     this.sendRequest("rejected");
   }
-  connect() {
-    console.log("✅ Controller connected");
-    console.log("🧪 userIdValue:", this.userIdValue);
-    console.log("🧪 blockedUserIdValue:", this.blockedUserIdValue);
-  }
 
-  block() {
-    console.log("hoge")
-    console.log("🧪 blockedUserIdValue:", this.blockedUserIdValue);
-    
+  block(e) {
     fetch("/blocks", {
       method: "POST",
       headers: {
@@ -38,14 +30,13 @@ export default class extends Controller {
     })
       .then((response) => {
         if (!response.ok) throw new Error("ブロック失敗");
-        return response.text();
-      })
-      .then((html) => {
-        const container = document.querySelector("#search-results");
-        if (container) container.innerHTML = html;
+        const requestItem = this.element.closest(".request-item");
+        if (requestItem) requestItem.remove();
       })
       .catch((error) => {
-        console.error("ブロックエラー:", error);
+        if (process.env.NODE_ENV === "development") {
+          console.error("ブロックエラー:", error);
+        }
       });
   }
 
@@ -64,7 +55,6 @@ export default class extends Controller {
     })
       .then((response) => {
         if (!response.ok) throw new Error("申請失敗");
-        console.log("✅ 申請リクエスト送信成功");
         return response.text();
       })
       .then((html) => {
@@ -73,11 +63,12 @@ export default class extends Controller {
         );
         if (target) {
           target.outerHTML = html;
-          console.log("DOM書き換え成功（送信者側）");
         }
       })
       .catch((error) => {
-        console.error("申請エラー:", error);
+        if (process.env.NODE_ENV === "development") {
+          console.error("申請エラー:", error);
+        }
       });
   }
 
@@ -98,7 +89,7 @@ export default class extends Controller {
         if (status === "accepted") {
           this.element.innerHTML = html;
         } else if (status === "rejected") {
-          const item = this.element.closest("li");
+          const item = this.element.closest(".request-item");
           if (item) item.remove();
 
           const remaining = document.querySelectorAll(".request-item");
@@ -111,7 +102,9 @@ export default class extends Controller {
         }
       })
       .catch((error) => {
-        console.error("リクエストエラー:", error);
+        if (process.env.NODE_ENV === "development") {
+          console.error("リクエストエラー:", error);
+        }
       });
   }
 }

--- a/app/javascript/controllers/friend_requests_controller.js
+++ b/app/javascript/controllers/friend_requests_controller.js
@@ -6,14 +6,11 @@ export default class extends Controller {
   static targets = ["list"];
 
   connect() {
-    console.log("subscribing:", this.userIdValue);
     this.subscription = createConsumer().subscriptions.create(
       { channel: "FriendRequestsChannel", id: this.userIdValue },
       {
         received: (html) => {
           this.listTarget.innerHTML = html;
-          console.log("📦 受信したHTML:", html);
-          console.log("リクエスト更新");
         },
       }
     );
@@ -22,7 +19,6 @@ export default class extends Controller {
   disconnect() {
     if (this.subscription) {
       this.subscription.unsubscribe();
-      console.log("リクエスト解除");
     }
   }
 }

--- a/app/views/layouts/leftSide/personal_chat/_friend_requests.html.erb
+++ b/app/views/layouts/leftSide/personal_chat/_friend_requests.html.erb
@@ -13,7 +13,8 @@
           <div class="request-actions"
                data-controller="friend-request-buttons"
                data-friend-request-buttons-id-value="<%= request.id %>"
-               data-friend-request-blocked-user-id-value="<%= request.sender.id %>">
+               data-friend-request-blocked-user-id-value="<%= request.sender.id %>"
+               data-friend-request-buttons-blocked-user-id-value="<%= request.sender.id %>">
             <button class="accept-btn" data-action="click->friend-request-buttons#accept">承認</button>
             <button class="reject-btn" data-action="click->friend-request-buttons#reject">拒否</button>
             <button class="block-btn" data-action="click->friend-request-buttons#block">ブロック</button>

--- a/app/views/layouts/leftSide/personal_chat/_request_button.html.erb
+++ b/app/views/layouts/leftSide/personal_chat/_request_button.html.erb
@@ -1,13 +1,8 @@
-<% puts "---- request_button partial START ----" %>
-<% puts "🔍 VIEW側：user.id = #{user.id} / current_user.id = #{current_user.id}" %>
-<% puts "🔍 received = #{current_user.received_friend_requests.where(sender_id: user.id).pluck(:status)}" %>
-<% puts "🔍 sent     = #{current_user.sent_friend_requests.where(receiver_id: user.id).pluck(:status)}" %>
-<% puts "---------------------------------------" %>
 <!-- buttonクリック後、リアルタイムにて切り替え -->
 <div id="friend-request-btn-<%= user.id %>"
      data-controller="friend-request-buttons"
      data-friend-request-buttons-user-id-value="<%= user.id %>"
-     data-friend-request-buttons-id-value="<%= friend_request&.id || '' %>"
+     data-friend-request-buttons-id-value="<%= friend_request&.id || 'null' %>"
      data-friend-request-buttons-blocked-user-id-value="<%= user.id %>">
   <% if current_user.friends.include?(user) %>
     <span class="friend-status">友達</span>

--- a/app/views/layouts/leftSide/personal_chat/_search_results.html.erb
+++ b/app/views/layouts/leftSide/personal_chat/_search_results.html.erb
@@ -1,17 +1,15 @@
 <!-- 検索結果 -->
 <div id="search-results">
-  <% if params[:name].present? %>
+  <% if defined?(search_results) && search_results.present? %>
     <% if search_results.any? %>
       <ul class="search-results">
         <% search_results.each do |user| %>
           <li class="search-item">
             <span class="user-name"><%= user.name %></span>
-            <div id="friend-request-btn-<%= user.id %>" data-controller="friend-request" data-friend-requests-user-id-value="<%= user.id %>">
-              <%= render "layouts/leftSide/personal_chat/request_button",
+            <%= render "layouts/leftSide/personal_chat/request_button",
                   user: user,
                   current_user: current_user,
                   friend_request: current_user.sent_friend_requests.find_by(receiver_id: user.id) %>
-            </div>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
## 概要
- ユーザーが他ユーザーをブロックした際、以下の箇所がリアルタイムで更新されるように対応しました。

## 変更点
- BlocksController#create に ActionCable による以下の broadcast を追加
  - ブロックしたユーザーの検索結果を更新
  - ブロックされたユーザーの検索結果を更新
  - ブロックしたユーザーのリクエスト一覧を更新
- `broadcast_search_results(user)` を private に定義
- Stimulusコントローラー側で、ブロック後に `.request-item` を削除
- 不要な console.log を開発環境限定に

## 動作確認
- ユーザーAがユーザーBをブロックすると、ユーザーBの検索結果からユーザーAが即座に非表示になることを確認
- ブロックした側のリクエスト一覧も即時更新されることを確認
- 本番環境で console.log が出力されないことを確認

## 備考
- 既存の `FriendRequestsController` 側にも同様の `broadcast_search_results` を後ほど適用予定
