### PR TITLE
group_chat_list 招待できないバグ修正

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,19 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+
+    def find_verified_user
+      if verified_user = env['warden'].user
+        verified_user
+      else
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/app/channels/group_chat_channel.rb
+++ b/app/channels/group_chat_channel.rb
@@ -1,0 +1,9 @@
+class GroupChatChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "group_chat_#{params[:chat_room_id]}"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/channels/user_group_chat_channel.rb
+++ b/app/channels/user_group_chat_channel.rb
@@ -1,6 +1,6 @@
 class UserGroupChatChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "user_#{params[:user_id]}_group_chat"
+    stream_from "user_group_chat_#{current_user.id}"
   end
 
   def unsubscribed

--- a/app/controllers/chat_rooms_controller.rb
+++ b/app/controllers/chat_rooms_controller.rb
@@ -51,17 +51,23 @@ class ChatRoomsController < ApplicationController
       ChatRoomUser.find_or_create_by(chat_room: @chat_room, user: friend)
 
       # 招待されたユーザー向けHTML
-      html = render_to_string(
-        partial: 'layouts/leftSide/group_chat/group_chat_item',
-        locals: { chat_room: @chat_room, current_user: friend }
-      )
+      begin
+        html = render_to_string(
+          partial: 'layouts/leftSide/group_chat/group_chat_item',
+          formats: [:html],
+          locals: { chat_room: @chat_room, current_user: friend }
+        )
 
-      ActionCable.server.broadcast(
-        "user_#{friend.id}_group_chat",
-        { html: html, chat_room_id: @chat_room.id }
-      )
+        ActionCable.server.broadcast(
+          "user_#{friend.id}_group_chat",
+          { html: html, chat_room_id: @chat_room.id }
+        )
 
-      render json: { success: true }
+        render json: { success: true }
+      rescue StandardError => e
+        Rails.logger.error("❌ 招待ビューのrender_to_stringでエラー: #{e.message}")
+        render json: { success: false, error: '招待の描画中にエラーが発生しました。' }, status: :internal_server_error
+      end
     else
       render json: {
         success: false, error: 'このユーザーはあなたの友達ではありません。'

--- a/app/controllers/group_chats_controller.rb
+++ b/app/controllers/group_chats_controller.rb
@@ -6,4 +6,55 @@ class GroupChatsController < ApplicationController
     @group_messages = @chat_room.group_messages.includes(:user)
     @group_message = GroupMessage.new
   end
+
+  def broadcast_updated_chat_item
+    chat_room = ChatRoom.find(params[:chat_room_id])
+
+    # グループチャットメンバー一覧HTML
+    members_html = render_to_string(
+      partial: 'layouts/leftSide/group_chat/participant_list',
+      locals: { chat_room: chat_room },
+      formats: [:html]
+    )
+
+    # 各ユーザーにブロードキャスト
+    chat_room.users.each do |user|
+      html = render_to_string(
+        partial: 'layouts/leftSide/group_chat/group_chat_item',
+        locals: { chat_room: chat_room, current_user: user },
+        formats: [:html]
+      )
+
+      ActionCable.server.broadcast(
+        "user_group_chat_#{user.id}",
+        {
+          type: 'update_members',
+          count_html: "#{chat_room.users.count}人",
+          members_html: members_html,
+          html: html,
+          chat_room_id: chat_room.id,
+          current: false
+        }
+      )
+
+      invite_candidates_html = render_to_string(
+        partial: 'layouts/leftSide/group_chat/invite_candidates',
+        locals: {
+          chat_room: chat_room,
+          invite_candidates: chat_room.invitable_users(user)
+        },
+        formats: [:html]
+      )
+
+      ActionCable.server.broadcast(
+        "user_group_chat_#{user.id}",
+        {
+          type: 'update_inviteCandidates',
+          html: invite_candidates_html
+        }
+      )
+    end
+
+    head :ok
+  end
 end

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,10 +1,11 @@
 // Import all the channels to be used by Action Cable
-import "channels/chat_channel"
-import "channels/group_channel"
-import "channels/friends_channel"
-import "channels/friend_search_channel"
-import "channels/friend_requests_channel"
-import "channels/search_results_channel"
-import "channels/friend_list_channel"
-import "channels/chat_list_channel"
-import "channels/user_group_chat_channel"
+import "channels/chat_channel";
+import "channels/group_channel";
+import "channels/friends_channel";
+import "channels/friend_search_channel";
+import "channels/friend_requests_channel";
+import "channels/search_results_channel";
+import "channels/friend_list_channel";
+import "channels/chat_list_channel";
+import "channels/user_group_chat_channel";
+import "channels/group_chat_channel";

--- a/app/javascript/channels/user_group_chat_channel.js
+++ b/app/javascript/channels/user_group_chat_channel.js
@@ -1,15 +1,49 @@
-import consumer from "channels/consumer"
+import consumer from "channels/consumer";
 
 consumer.subscriptions.create("UserGroupChatChannel", {
   connected() {
-    // Called when the subscription is ready for use on the server
+    console.log("✅ UserGroupChatChannel connected");
   },
 
-  disconnected() {
-    // Called when the subscription has been terminated by the server
-  },
+  disconnected() {},
 
   received(data) {
-    // Called when there's incoming data on the websocket for this channel
-  }
+    console.log("📩 受信:", data);
+
+    // メンバー表示の更新（人数とリスト）
+    if (data.type === "update_members") {
+      const countElem = document.querySelector("#participant-count");
+      const listElem = document.querySelector("#participant-list");
+
+      if (countElem) countElem.innerHTML = data.count_html;
+      if (listElem) listElem.innerHTML = data.members_html;
+    }
+
+    // 招待候補の更新
+    if (data.type === "update_inviteCandidates") {
+      const wrapper = document.getElementById("group-invite-wrapper");
+      if (wrapper) {
+        wrapper.innerHTML = data.html;
+      } else {
+        console.warn("group-invite-formが見つからない");
+      }
+    }
+
+    // チャット項目（左側リスト）の更新
+    if (data.type === "invited" || (data.chat_room_id && data.html)) {
+      const id = `group-chat-item-${data.chat_room_id}`;
+      const existing = document.getElementById(id);
+
+      const targetList = data.current
+        ? "current-group-chat-list"
+        : "other-group-chat-list";
+
+      if (existing) {
+        existing.outerHTML = data.html;
+      } else {
+        const list = document.getElementById(targetList);
+        if (list) list.insertAdjacentHTML("beforeend", data.html);
+      }
+    }
+  },
 });

--- a/app/javascript/controllers/group/group_invite_form_controller.js
+++ b/app/javascript/controllers/group/group_invite_form_controller.js
@@ -1,0 +1,67 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = { chatRoomId: Number };
+
+  connect() {
+    console.log("🧩 group--group-invite-form controller connected");
+  }
+
+  async submit(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const csrfToken = document.querySelector(
+      "meta[name='csrf-token']"
+    )?.content;
+
+    console.log("✅ invite fetch start");
+
+    try {
+      const response = await fetch(
+        `/chat_rooms/${this.chatRoomIdValue}/invite`,
+        {
+          method: "POST",
+          headers: {
+            "X-CSRF-Token": csrfToken,
+            Accept: "application/json",
+          },
+          body: formData,
+        }
+      );
+
+      const text = await response.text();
+      try {
+        const data = JSON.parse(text);
+
+        if (response.ok && data.success) {
+          form.reset();
+          this.showError("");
+          await fetch("/group_chats/broadcast_updated_chat_item", {
+            method: "POST",
+            headers: {
+              "X-CSRF-Token": csrfToken,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ chat_room_id: this.chatRoomIdValue }),
+          });
+        } else {
+          this.showError(data.error || "招待に失敗しました");
+        }
+      } catch (jsonError) {
+        console.error("JSONパース失敗:", text);
+        this.showError("予期しないレスポンス形式が返されました");
+      }
+    } catch (e) {
+      this.showError("ネットワークエラーが発生しました");
+      console.error(e);
+    }
+  }
+
+  showError(message) {
+    const errorBox = document.getElementById("invite-error");
+    if (errorBox) {
+      errorBox.textContent = message;
+    }
+  }
+}

--- a/app/models/chat_room.rb
+++ b/app/models/chat_room.rb
@@ -9,6 +9,10 @@ class ChatRoom < ApplicationRecord
     users.find_by(id: creator_id)
   end
 
+  def sorted_members
+    users.order(:id)
+  end
+
   # 自分以外の未読メッセージ数
   def unread_count_for(user)
     group_messages
@@ -27,5 +31,13 @@ class ChatRoom < ApplicationRecord
       .find_each do |message|
         GroupMessageRead.create(user: user, group_message: message, chat_room: self)
       end
+  end
+
+  # 自身の友達でないユーザー or 既にグループチャットにいるユーザー除外
+  def invitable_users(current_user)
+    friend_ids = current_user.friends.pluck(:id)
+    joined_ids = users.pluck(:id)
+
+    User.where(id: friend_ids - joined_ids)
   end
 end

--- a/app/views/layouts/leftSide/group_chat/_group_invite_form.html.erb
+++ b/app/views/layouts/leftSide/group_chat/_group_invite_form.html.erb
@@ -1,31 +1,16 @@
 <div id="group-invite-wrapper">
   <% if @chat_room.present? %>
     <% if @invite_candidates.any? %>
-      <div class="group-invite-form"
-           id="group-invite-form"
-           data-controller="group--group-invite-form"
-           data-group--group-invite-form-chat-room-id-value="<%= @chat_room.id %>">
-        <form data-action="submit->group--group-invite-form#submit">
-          <%= select_tag :user_id,
-              options_from_collection_for_select(@invite_candidates, :id, :name),
-              prompt: "選択してください", class: "invite-select", required: true %>
-          <button type="submit" class="invite-button">招待する</button>
-        </form>
-        <div id="invite-error" class="form-errors"></div>
-      </div>
+      <%= render partial: "layouts/leftSide/group_chat/invite_candidates",
+                 locals: { chat_room: @chat_room, invite_candidates: @invite_candidates } %>
     <% else %>
       <p>招待できる友達がいません。</p>
     <% end %>
     <div class="group-members-list">
-      <p class="member-title">現在のメンバー:</p>
-      <ul class="member-scroll">
-        <% @sorted_members.each do |member| %>
-          <li>
-            <%= member.name %>
-            <%= '（作成者）' if member.id == @chat_room.creator_id %>
-          </li>
-        <% end %>
-      </ul>
+      <p class="member-title">
+        現在のメンバー: <span id="participant-count"><%= @chat_room.users.count %>人</span>
+      </p>
+      <%= render partial: "layouts/leftSide/group_chat/participant_list", locals: { chat_room: @chat_room } %>
     </div>
   <% end %>
 </div>

--- a/app/views/layouts/leftSide/group_chat/_invite_candidates.html.erb
+++ b/app/views/layouts/leftSide/group_chat/_invite_candidates.html.erb
@@ -1,0 +1,19 @@
+<% if invite_candidates.any? %>
+  <div class="group-invite-form" id="group-invite-form">
+    <form
+       data-controller="group--group-invite-form"
+       data-group--group-invite-form-chat-room-id-value="<%= chat_room.id %>"
+       data-action="submit->group--group-invite-form#submit">
+      <select name="user_id" class="invite-select" required>
+        <option value="">選択してください</option>
+        <% invite_candidates.each do |user| %>
+          <option value="<%= user.id %>"><%= user.name %></option>
+        <% end %>
+      </select>
+      <button type="submit" class="invite-button">招待する</button>
+    </form>
+    <div id="invite-error" class="form-errors"></div>
+  </div>
+<% else %>
+  <p>招待できる友達がいません。</p>
+<% end %>

--- a/app/views/layouts/leftSide/group_chat/_participant_list.html.erb
+++ b/app/views/layouts/leftSide/group_chat/_participant_list.html.erb
@@ -1,0 +1,8 @@
+<ul class="member-scroll" id="participant-list">
+  <% chat_room.sorted_members.each do |member| %>
+    <li>
+      <%= member.name %>
+      <%= '（作成者）' if member.id == chat_room.creator_id %>
+    </li>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   post 'chat_rooms/:id/invite', to: 'chat_rooms#invite', as: :invite_to_chat_room
   post 'start_chat/:id', to: 'users#start_chat', as: :start_chat_user
   post 'messages/:id/mark_as_read', to: 'messages#mark_as_read'
+  post 'group_chats/broadcast_updated_chat_item', to: 'group_chats#broadcast_updated_chat_item'
 
   devise_for :users, controllers: {
     registrations: 'users/registrations',
@@ -25,7 +26,6 @@ Rails.application.routes.draw do
       post :mark_as_read
     end
   end
-
 
   resources :messages, only: [:create]
   resources :friendships, only: [:index]


### PR DESCRIPTION
✅ 概要
グループチャットの招待や参加に関連するリアルタイム更新を改善しました。

🔧 主な修正点
招待後に 参加メンバーリストと人数をリアルタイムで更新

招待候補ユーザーのリストも自動で更新（除外処理含む）

ActionCable を通じて各ユーザーごとに更新を配信

group_chat_item, participant_list, invite_candidates の各部分テンプレートを整理

🐛 修正済みバグ
招待後に「招待できる友達がいません」の表示に切り替わらない不具合を修正

<select> にユーザーが残り続ける問題を修正

🚧 既知の課題（次の対応範囲）
新規グルチャ作成フォームが非表示になる不具合（今後修正予定）

