### PR TITLE
fix(left-side): 同じチャット閲覧中は未読バッジを増やさないようにする

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -37,10 +37,16 @@ class MessagesController < ApplicationController
 
   def mark_as_read
     message = Message.find(params[:id])
-    return unless message.user_id != current_user.id && !message.read
+    return head :forbidden if message.user_id == current_user.id
+    return head :ok if message.read?
 
-    message.update(read: true)
+    message.update!(read: true)
 
+    html = render_to_string(
+      partial: 'layouts/leftSide/personal_chat/chat_list',
+      locals: { all_chats: current_user.chats.order(updated_at: :desc), current_user: current_user }
+    )
+    ActionCable.server.broadcast("chat_list_#{current_user.id}", html)
     head :ok
   end
 

--- a/app/javascript/controllers/personal/chat_list_controller.js
+++ b/app/javascript/controllers/personal/chat_list_controller.js
@@ -9,9 +9,22 @@ export default class extends Controller {
     this.subscription = createConsumer().subscriptions.create(
       { channel: "ChatListChannel", user_id: this.userIdValue },
       {
-        received: (html) => {
-          if (this.hasListTarget) {
-            this.listTarget.innerHTML = html;
+        received: (payload) => {
+          if (!this.hasListTarget) return;
+
+          // 文字列 or html 両対応
+          const html = typeof payload === "string" ? payload : payload?.html;
+          if (!html) return;
+
+          this.listTarget.innerHTML = html;
+
+          // いま表示中の chat_id の未読だけ消す
+          const id = new URLSearchParams(location.search).get("chat_id");
+          if (id) {
+            const wrap = this.listTarget.querySelector(
+              `#unread-count-personal-${CSS.escape(id)}`
+            );
+            if (wrap) wrap.innerHTML = "";
           }
         },
       }

--- a/app/views/user_group_chats/destroy.html.erb
+++ b/app/views/user_group_chats/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>UserGroupChats#destroy</h1>
-<p>Find me in app/views/user_group_chats/destroy.html.erb</p>


### PR DESCRIPTION
概要

個人チャットを双方が同時に閲覧している場合でも、左サイドの未読バッジが増えることがあった。
ChatListChannel 受信後に、現在URLの chat_id と一致するチャットの未読表示を即時クリアすることで、見ているスレッドで未読が積み上がる挙動を解消。
あわせて messages#mark_as_read 後に、自分用のチャット一覧を再配信してUIを同期。

変更点

app/javascript/controllers/personal/chat_list_controller.js
received を強化：文字列/オブジェクト両対応（payload?.html も許容）
HTML差し替え後、URLの ?chat_id= と一致する #unread-count-personal-<id> を空にして未読バッジを消去
app/controllers/messages_controller.rb
mark_as_read 成功時に、自分の左リスト部分テンプレートを再描画→ ActionCable で chat_list_<user_id> に配信